### PR TITLE
Long Message in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ or manually using this URL:
 
 Once you have wired up the HX711, it must be calibrated. This is a pretty straightforward process, and all you will need is an object of known weight. Attach the load cell to your printer with the printed bracket, then follow the instructions on the plugin's settings page.
 
+## Troubleshooting
+
+`NaN` may be occasionally displayed in the interface when the weight can't be read correctly. The cheap boards vary in quality and are a little sensitive to vibration/power stability. Ensure the cabling is secure, you have a sufficiently sized load cell, and a good power supply.
+
 ## Development
 
 Python 3 + Python 3 Virtualenv recommended

--- a/filament_scale_enhanced/static/js/filament_scale.js
+++ b/filament_scale_enhanced/static/js/filament_scale.js
@@ -53,7 +53,7 @@ $(function() {
 				
 			self.last_raw_weight = parseInt(message)
 			if (parseInt(message) == 8388608 || parseInt(message) == 8388607){
-				self.printerState.filamentRemainingString("Sensor Not Connected")
+				self.printerState.filamentRemainingString("NaN")
 				self.settings.settings.plugins.filament_scale.lastknownweight("Error")
 			} else {
 				weight = self.getWeight(message)


### PR DESCRIPTION
The 'Sensor Not Connected' message was both long and slightly inaccurate. Which lead to the interface jumping around whenever a string of bad readings came through. Shortened the error to 'NaN' and documented it in the README.