### PR TITLE
Fix typo in default settings

### DIFF
--- a/filament_scale_enhanced/__init__.py
+++ b/filament_scale_enhanced/__init__.py
@@ -31,7 +31,7 @@ class FilamentScalePlugin(octoprint.plugin.SettingsPlugin,
     def get_settings_defaults():
         return dict(
             tare=8430152,
-            refernce_unit=-411,
+            reference_unit=-411,
             spool_weight=200,
             clockpin=21,
             datapin=20,


### PR DESCRIPTION
This typo causes the plugin to fail for new installations. If you
have already configured it, these values are not used.

Fixes #12